### PR TITLE
Add `SendFindNodeAsync` API that supports custom distances

### DIFF
--- a/src/Lantern.Discv5.WireProtocol/Discv5Protocol.cs
+++ b/src/Lantern.Discv5.WireProtocol/Discv5Protocol.cs
@@ -118,6 +118,20 @@ public class Discv5Protocol(IConnectionManager connectionManager,
         }
     }
 
+    public async Task<IEnumerable<IEnr>?> SendFindNodeAsync(IEnr destination, int[] distances)
+    {
+        try
+        {
+            var response = await packetReceiver.SendFindNodeAsync(destination, distances);
+            return response;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error occurred in SendFindNodeAsync. Cannot send FINDNODE to {Record}", destination);
+            return null;
+        }
+    }
+
     public async Task<bool> SendTalkReqAsync(IEnr destination, byte[] protocol, byte[] request)
     {
         try

--- a/src/Lantern.Discv5.WireProtocol/IDiscv5Protocol.cs
+++ b/src/Lantern.Discv5.WireProtocol/IDiscv5Protocol.cs
@@ -1,8 +1,6 @@
 using Lantern.Discv5.Enr;
 using Lantern.Discv5.WireProtocol.Messages.Responses;
 using Lantern.Discv5.WireProtocol.Table;
-using Lantern.Discv5.WireProtocol.Messages.Responses;
-using Lantern.Discv5.WireProtocol.Table;
 
 namespace Lantern.Discv5.WireProtocol;
 
@@ -37,6 +35,8 @@ public interface IDiscv5Protocol
     Task<PongMessage?> SendPingAsync(IEnr destination);
 
     Task<IEnumerable<IEnr>?> SendFindNodeAsync(IEnr destination, byte[] targetNodeId);
+
+    Task<IEnumerable<IEnr>?> SendFindNodeAsync(IEnr destination, int[] distances);
 
     Task<bool> SendTalkReqAsync(IEnr destination, byte[] protocol, byte[] request);
 

--- a/src/Lantern.Discv5.WireProtocol/Messages/IMessageRequester.cs
+++ b/src/Lantern.Discv5.WireProtocol/Messages/IMessageRequester.cs
@@ -6,9 +6,9 @@ public interface IMessageRequester
 
     byte[]? ConstructCachedPingMessage(byte[] destNodeId);
 
-    byte[]? ConstructFindNodeMessage(byte[] destNodeId, bool isLookupPacket, byte[] targetNodeId);
+    byte[]? ConstructFindNodeMessage(byte[] destNodeId, bool isLookupPacket, int[] distances);
 
-    byte[]? ConstructCachedFindNodeMessage(byte[] destNodeId, bool isLookupPacket, byte[] targetNodeId);
+    byte[]? ConstructCachedFindNodeMessage(byte[] destNodeId, bool isLookupPacket, int[] distances);
 
     byte[]? ConstructTalkReqMessage(byte[] destNodeId, byte[] protocol, byte[] request);
 

--- a/src/Lantern.Discv5.WireProtocol/Messages/MessageRequester.cs
+++ b/src/Lantern.Discv5.WireProtocol/Messages/MessageRequester.cs
@@ -46,11 +46,8 @@ public class MessageRequester(IIdentityManager identityManager, IRequestManager 
         return pingMessage.EncodeMessage();
     }
 
-    public byte[]? ConstructFindNodeMessage(byte[] destNodeId, bool isLookupRequest, byte[] targetNodeId)
+    public byte[]? ConstructFindNodeMessage(byte[] destNodeId, bool isLookupRequest, int[] distances)
     {
-        var distance = TableUtility.Log2Distance(destNodeId, targetNodeId);
-        var distances = new[] { distance };
-
         _logger.LogInformation("Constructing message of type {MessageType} at distances {Distances}", MessageType.FindNode, string.Join(", ", distances.Select(d => d.ToString())));
 
         var findNodesMessage = new FindNodeMessage(distances);
@@ -70,11 +67,8 @@ public class MessageRequester(IIdentityManager identityManager, IRequestManager 
         return findNodesMessage.EncodeMessage();
     }
 
-    public byte[]? ConstructCachedFindNodeMessage(byte[] destNodeId, bool isLookupRequest, byte[] targetNodeId)
+    public byte[]? ConstructCachedFindNodeMessage(byte[] destNodeId, bool isLookupRequest, int[] distances)
     {
-        var distance = TableUtility.Log2Distance(destNodeId, targetNodeId);
-        var distances = new[] { distance };
-
         _logger.LogInformation("Constructing message of type {MessageType} at distances {Distances}", MessageType.FindNode, string.Join(", ", distances.Select(d => d.ToString())));
 
         var findNodesMessage = new FindNodeMessage(distances);

--- a/src/Lantern.Discv5.WireProtocol/Packet/IPacketManager.cs
+++ b/src/Lantern.Discv5.WireProtocol/Packet/IPacketManager.cs
@@ -6,7 +6,7 @@ namespace Lantern.Discv5.WireProtocol.Packet;
 
 public interface IPacketManager
 {
-    Task<byte[]?> SendPacket(IEnr dest, MessageType messageType, bool isLookup, params byte[][] args);
+    Task<byte[]?> SendPacket(IEnr dest, MessageType messageType, bool isLookup, params object[] args);
 
     Task HandleReceivedPacket(UdpReceiveResult returnedResult);
 }

--- a/src/Lantern.Discv5.WireProtocol/Packet/IPacketReceiver.cs
+++ b/src/Lantern.Discv5.WireProtocol/Packet/IPacketReceiver.cs
@@ -11,6 +11,8 @@ public interface IPacketReceiver
 
     Task<IEnr[]?> SendFindNodeAsync(IEnr dest, byte[] targetNodeId);
 
+    Task<IEnr[]?> SendFindNodeAsync(IEnr dest, int[] distances);
+
     void RaisePongResponseReceived(PongResponseEventArgs e);
 
     void RaiseNodesResponseReceived(NodesResponseEventArgs e);

--- a/src/Lantern.Discv5.WireProtocol/Packet/PacketReceiver.cs
+++ b/src/Lantern.Discv5.WireProtocol/Packet/PacketReceiver.cs
@@ -2,6 +2,7 @@ using Lantern.Discv5.Enr;
 using Lantern.Discv5.WireProtocol.Connection;
 using Lantern.Discv5.WireProtocol.Messages;
 using Lantern.Discv5.WireProtocol.Messages.Responses;
+using Lantern.Discv5.WireProtocol.Table;
 using Microsoft.Extensions.Logging;
 
 namespace Lantern.Discv5.WireProtocol.Packet;
@@ -51,9 +52,12 @@ public class PacketReceiver(IPacketManager packetManager,
         }
     }
 
-    public async Task<IEnr[]?> SendFindNodeAsync(IEnr dest, byte[] targetNodeId)
+    public Task<IEnr[]?> SendFindNodeAsync(IEnr dest, byte[] targetNodeId)
+        => SendFindNodeAsync(dest, [TableUtility.Log2Distance(dest.NodeId, targetNodeId)]);
+
+    public async Task<IEnr[]?> SendFindNodeAsync(IEnr dest, int[] distances)
     {
-        var payload = await packetManager.SendPacket(dest, MessageType.FindNode, false, targetNodeId);
+        var payload = await packetManager.SendPacket(dest, MessageType.FindNode, false, distances);
 
         if (payload is null)
         {
@@ -72,7 +76,7 @@ public class PacketReceiver(IPacketManager packetManager,
         if (completedTask != delayTask)
             return await tcs.Task;
 
-        _logger.LogWarning("FINDNODE request to {NodeId} timed out", Convert.ToHexString(targetNodeId));
+        _logger.LogWarning("FINDNODE request to {NodeId} timed out", Convert.ToHexString(dest.NodeId));
         NodesResponseReceived -= HandleNodesResponse;
         return null;
 

--- a/src/Lantern.Discv5.WireProtocol/Table/LookupManager.cs
+++ b/src/Lantern.Discv5.WireProtocol/Table/LookupManager.cs
@@ -166,7 +166,7 @@ public class LookupManager(IRoutingTable routingTable,
             connectionOptions.ReceiveTimeoutMs, connectionOptions.ReceiveTimeoutMs);
         bucket.PendingQueries.Add(node.Id);
 
-        await packetManager.SendPacket(node.Record, MessageType.FindNode, true, bucket.TargetNodeId);
+        await packetManager.SendPacket(node.Record, MessageType.FindNode, true, TableUtility.Log2Distance(node.Record.NodeId, bucket.TargetNodeId));
     }
 
     private async Task QueryClosestNodes(PathBucket bucket, byte[] senderNodeId)

--- a/tests/Lantern.Discv5.WireProtocol.Tests/Discv5ProtocolMockTests.cs
+++ b/tests/Lantern.Discv5.WireProtocol.Tests/Discv5ProtocolMockTests.cs
@@ -228,6 +228,25 @@ public class Discv5ProtocolMockTests
         Assert.IsNotNull(result);
     }
 
+    [TestCase([0])]
+    [TestCase([256])]
+    [TestCase([254, 255, 256])]
+    public async Task SendFindNodeAsync_ShouldSendDistances(params int[] distances)
+    {
+        var enrEntryRegistry = new EnrEntryRegistry();
+        var enrRecord = new EnrFactory(enrEntryRegistry).CreateFromString("enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8", new IdentityVerifierV4());
+
+        mockPacketReceiver
+            .Setup(x => x.SendFindNodeAsync(It.IsAny<Enr.Enr>(), It.IsAny<int[]>()))
+            .Returns(Task.FromResult(new IEnr[] { enrRecord })!);
+
+        SetupServices();
+
+        var result = await _discv5Protocol.SendFindNodeAsync(enrRecord, distances);
+
+        mockPacketReceiver.Verify(x => x.SendFindNodeAsync(enrRecord, distances), Times.Once);
+    }
+
     [Test]
     public async Task SendFindNodeAsync_ShouldReturnFalse_WhenExceptionIsThrown()
     {
@@ -255,12 +274,12 @@ public class Discv5ProtocolMockTests
         var enrRecord = new EnrFactory(enrEntryRegistry).CreateFromString("enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8", new IdentityVerifierV4());
 
         mockPacketManager
-            .Setup(x => x.SendPacket(It.IsAny<Enr.Enr>(), It.IsAny<MessageType>(), It.IsAny<bool>(), It.IsAny<byte[][]>()))
+            .Setup(x => x.SendPacket(It.IsAny<Enr.Enr>(), It.IsAny<MessageType>(), It.IsAny<bool>(), It.IsAny<object[]>()))
             .Returns(Task.FromResult(new byte[0]));
 
         SetupServices();
         var result = await _discv5Protocol.SendTalkReqAsync(enrRecord, RandomUtility.GenerateRandomData(32), RandomUtility.GenerateRandomData(32));
-        mockPacketManager.Verify(x => x.SendPacket(enrRecord, MessageType.TalkReq, It.IsAny<bool>(), It.IsAny<byte[][]>()), Times.Once);
+        mockPacketManager.Verify(x => x.SendPacket(enrRecord, MessageType.TalkReq, It.IsAny<bool>(), It.IsAny<object[]>()), Times.Once);
         Assert.IsTrue(result);
     }
 
@@ -272,13 +291,13 @@ public class Discv5ProtocolMockTests
         var exceptionToThrow = new Exception("Test exception");
 
         mockPacketManager
-            .Setup(x => x.SendPacket(It.IsAny<Enr.Enr>(), It.IsAny<MessageType>(), It.IsAny<bool>(), It.IsAny<byte[][]>()))
+            .Setup(x => x.SendPacket(It.IsAny<Enr.Enr>(), It.IsAny<MessageType>(), It.IsAny<bool>(), It.IsAny<object[]>()))
             .ThrowsAsync(exceptionToThrow);
 
         SetupServices();
 
         var result = await _discv5Protocol.SendTalkReqAsync(enrRecord, RandomUtility.GenerateRandomData(32), RandomUtility.GenerateRandomData(32));
-        mockPacketManager.Verify(x => x.SendPacket(enrRecord, MessageType.TalkReq, It.IsAny<bool>(), It.IsAny<byte[][]>()), Times.Once);
+        mockPacketManager.Verify(x => x.SendPacket(enrRecord, MessageType.TalkReq, It.IsAny<bool>(), It.IsAny<object[]>()), Times.Once);
         Assert.IsFalse(result);
     }
 

--- a/tests/Lantern.Discv5.WireProtocol.Tests/MessageRequesterTests.cs
+++ b/tests/Lantern.Discv5.WireProtocol.Tests/MessageRequesterTests.cs
@@ -89,15 +89,17 @@ public class MessageRequesterTests
     {
         var destNodeId = RandomUtility.GenerateRandomData(32);
         var targetNodeId = RandomUtility.GenerateRandomData(32);
-        var findNodeMessage = _messageRequester.ConstructFindNodeMessage(destNodeId, false, targetNodeId)!;
-        var cachedFindNodeMessage = _messageRequester.ConstructCachedFindNodeMessage(destNodeId, false, targetNodeId)!;
+
+        int distance = TableUtility.Log2Distance(destNodeId, targetNodeId);
+        var findNodeMessage = _messageRequester.ConstructFindNodeMessage(destNodeId, false, [distance])!;
+        var cachedFindNodeMessage = _messageRequester.ConstructCachedFindNodeMessage(destNodeId, false, [distance])!;
         var decodedFindNodeMessage = (FindNodeMessage)new MessageDecoder(_identityManager, _enrFactory).DecodeMessage(findNodeMessage);
         var decodedCachedFindNodeMessage = (FindNodeMessage)new MessageDecoder(_identityManager, _enrFactory).DecodeMessage(cachedFindNodeMessage);
 
         Assert.AreEqual(MessageType.FindNode, decodedFindNodeMessage.MessageType);
-        Assert.AreEqual(TableUtility.Log2Distance(targetNodeId, destNodeId), decodedFindNodeMessage.Distances.First());
+        Assert.AreEqual(distance, decodedFindNodeMessage.Distances.First());
         Assert.AreEqual(MessageType.FindNode, decodedCachedFindNodeMessage.MessageType);
-        Assert.AreEqual(TableUtility.Log2Distance(targetNodeId, destNodeId), decodedCachedFindNodeMessage.Distances.First());
+        Assert.AreEqual(distance, decodedCachedFindNodeMessage.Distances.First());
     }
 
     [Test]
@@ -155,8 +157,8 @@ public class MessageRequesterTests
         var destNodeId = RandomUtility.GenerateRandomData(32);
         var pingResult = messageRequester.ConstructPingMessage(destNodeId);
         var cachedPingResult = messageRequester.ConstructCachedPingMessage(destNodeId);
-        var findNodeResult = messageRequester.ConstructFindNodeMessage(destNodeId, false, destNodeId);
-        var cachedFindNodeResult = messageRequester.ConstructCachedFindNodeMessage(destNodeId, false, destNodeId);
+        var findNodeResult = messageRequester.ConstructFindNodeMessage(destNodeId, false, [0]);
+        var cachedFindNodeResult = messageRequester.ConstructCachedFindNodeMessage(destNodeId, false, [0]);
         var talkRequestResult = messageRequester.ConstructTalkReqMessage(destNodeId, "discv5"u8.ToArray(), "ping"u8.ToArray());
         var cachedTalkRequestResult = messageRequester.ConstructCachedTalkReqMessage(destNodeId, "discv5"u8.ToArray(), "ping"u8.ToArray());
         var talkResponseResult = messageRequester.ConstructTalkRespMessage(destNodeId, "response"u8.ToArray());


### PR DESCRIPTION
Allow `SendFindNodeAsync` to be called with specific distances, which unlocks custom discovery