### PR TITLE
Update BC; remove Open.Nat as not used and not supporting .NET 8

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,8 +9,7 @@
     <PackageVersion Include="Multiformats.Base" Version="2.0.1" />
     <PackageVersion Include="Multiformats.Hash" Version="1.3.0" />
     <PackageVersion Include="NBitcoin.Secp256k1" Version="3.1.4" />
-    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.3.0" />
-    <PackageVersion Include="Open.Nat" Version="2.1.0" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.3.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />

--- a/src/Lantern.Discv5.Enr/Lantern.Discv5.Enr.csproj
+++ b/src/Lantern.Discv5.Enr/Lantern.Discv5.Enr.csproj
@@ -11,7 +11,6 @@
         <PackageReference Include="Multiformats.Base"/>
         <PackageReference Include="Multiformats.Hash"/>
         <PackageReference Include="NBitcoin.Secp256k1"/>
-        <PackageReference Include="Open.Nat"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Lantern.Discv5.Rlp/Lantern.Discv5.Rlp.csproj
+++ b/src/Lantern.Discv5.Rlp/Lantern.Discv5.Rlp.csproj
@@ -6,8 +6,4 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Open.Nat"/>
-    </ItemGroup>
-
 </Project>

--- a/src/Lantern.Discv5.WireProtocol/Lantern.Discv5.WireProtocol.csproj
+++ b/src/Lantern.Discv5.WireProtocol/Lantern.Discv5.WireProtocol.csproj
@@ -19,7 +19,6 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" />
         <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="NBitcoin.Secp256k1"/>
-        <PackageReference Include="Open.Nat"/>
         <PackageReference Include="System.Threading.Tasks.Dataflow"/>
     </ItemGroup>
 

--- a/tests/Lantern.Discv5.Enr.Tests/Lantern.Discv5.Enr.Tests.csproj
+++ b/tests/Lantern.Discv5.Enr.Tests/Lantern.Discv5.Enr.Tests.csproj
@@ -21,7 +21,6 @@
         <PackageReference Include="Multiformats.Hash" Version="1.5.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-        <PackageReference Include="Open.Nat" Version="2.1.0" />
     </ItemGroup>
 
 </Project>

--- a/tests/Lantern.Discv5.Rlp.Tests/Lantern.Discv5.Rlp.Tests.csproj
+++ b/tests/Lantern.Discv5.Rlp.Tests/Lantern.Discv5.Rlp.Tests.csproj
@@ -15,7 +15,6 @@
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-        <PackageReference Include="Open.Nat" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Lantern.Discv5.WireProtocol.Tests/Lantern.Discv5.WireProtocol.Tests.csproj
+++ b/tests/Lantern.Discv5.WireProtocol.Tests/Lantern.Discv5.WireProtocol.Tests.csproj
@@ -18,7 +18,6 @@
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-        <PackageReference Include="Open.Nat" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Update BouncyCastle to the safe version
- Remove Open.Nat as not used and not supporting .NET 8