### PR TITLE
Fix listening, lookup, readme

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
 		<Authors>Pier Two</Authors>
 		<Copyright>Pier Two Services Pty Ltd</Copyright>
 		<VersionPrefix>1.0.0</VersionPrefix>
-		<VersionSuffix>preview.1</VersionSuffix>
+		<VersionSuffix>preview.2</VersionSuffix>
 	</PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-
-<div align="center">
-  <h1 align="center">Lantern.Discv5</h1>
-</div>
+# <center>Lantern.Discv5</center>
 
 Lantern.Discv5, written in C#, is a library that provides an implementation of the [Node Discovery V5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md) protocol. 
 

--- a/src/Lantern.Discv5.WireProtocol/Packet/PacketReceiver.cs
+++ b/src/Lantern.Discv5.WireProtocol/Packet/PacketReceiver.cs
@@ -57,7 +57,7 @@ public class PacketReceiver(IPacketManager packetManager,
 
     public async Task<IEnr[]?> SendFindNodeAsync(IEnr dest, int[] distances)
     {
-        var payload = await packetManager.SendPacket(dest, MessageType.FindNode, false, distances.Cast<object>().ToArray());
+        var payload = await packetManager.SendPacket(dest, MessageType.FindNode, true, distances.Cast<object>().ToArray());
 
         if (payload is null)
         {


### PR DESCRIPTION
- Listen after exception
- Lookup mode for `SendFindNodeAsync` override
- Attempt to improve readme header visible in [nuget](https://www.nuget.org/packages/PierTwo.Lantern.Discv5)