### PR TITLE
Refactor NuGet packaging

### DIFF
--- a/.github/workflows/discv5.yml
+++ b/.github/workflows/discv5.yml
@@ -53,10 +53,9 @@ jobs:
 
       - name: Publish package
         if: ${{ inputs.publish }}
-        working-directory: src/Lantern.Discv5.WireProtocol
         run: |
           dotnet pack -c ${{ env.BUILD_CONFIG }} --no-build
-          dotnet nuget push bin/${{ env.BUILD_CONFIG }}/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+          dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
   sonar:
     name: Build and analyze SonarCloud

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,17 @@
 	<PropertyGroup>
 		<Authors>Pier Two</Authors>
 		<Copyright>Pier Two Services Pty Ltd</Copyright>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://piertwo.com</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageTags>network p2p discv5</PackageTags>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/Pier-Two/Lantern.Discv5</RepositoryUrl>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<VersionPrefix>1.0.0</VersionPrefix>
-		<VersionSuffix>preview.2</VersionSuffix>
+		<VersionSuffix>preview.3</VersionSuffix>
 	</PropertyGroup>
 
 </Project>

--- a/src/Lantern.Discv5.Enr/Lantern.Discv5.Enr.csproj
+++ b/src/Lantern.Discv5.Enr/Lantern.Discv5.Enr.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -6,18 +6,24 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+	<PropertyGroup>
+		<Description>Ethereum Node Records (ENR) implementation for the Node Discovery Protocol v5.</Description>
+		<PackageId>PierTwo.Lantern.Discv5.Enr</PackageId>
+	</PropertyGroup>
+
     <ItemGroup>
-        <PackageReference Include="Keccak256"/>
-        <PackageReference Include="Multiformats.Base"/>
-        <PackageReference Include="Multiformats.Hash"/>
-        <PackageReference Include="NBitcoin.Secp256k1"/>
+        <PackageReference Include="Keccak256" />
+        <PackageReference Include="Multiformats.Base" />
+        <PackageReference Include="Multiformats.Hash" />
+        <PackageReference Include="NBitcoin.Secp256k1" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Lantern.Discv5.Rlp\Lantern.Discv5.Rlp.csproj" />
     </ItemGroup>
 
-
-
+	<ItemGroup>
+		<None Include="../../README.md" Pack="true" PackagePath="/" />
+	</ItemGroup>
 
 </Project>

--- a/src/Lantern.Discv5.Rlp/Lantern.Discv5.Rlp.csproj
+++ b/src/Lantern.Discv5.Rlp/Lantern.Discv5.Rlp.csproj
@@ -6,4 +6,13 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+	<PropertyGroup>
+		<Description>RLP implementation for the Node Discovery Protocol v5.</Description>
+		<PackageId>PierTwo.Lantern.Discv5.Rlp</PackageId>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="../../README.md" Pack="true" PackagePath="/" />
+	</ItemGroup>
+
 </Project>

--- a/src/Lantern.Discv5.WireProtocol/Lantern.Discv5.WireProtocol.csproj
+++ b/src/Lantern.Discv5.WireProtocol/Lantern.Discv5.WireProtocol.csproj
@@ -7,17 +7,8 @@
     </PropertyGroup>
 
 	<PropertyGroup>
-		<Description>C# implementation of the Discv5 protocol.</Description>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<IncludeSymbols>true</IncludeSymbols>
-		<PackageId>PierTwo.Lantern.Discv5</PackageId>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageProjectUrl>https://piertwo.com</PackageProjectUrl>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageTags>network p2p discv5</PackageTags>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/Pier-Two/Lantern.Discv5</RepositoryUrl>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<Description>C# implementation of the Node Discovery Protocol v5.</Description>
+		<PackageId>PierTwo.Lantern.Discv5.WireProtocol</PackageId>
 	</PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated the NuGet packaging with the first approach suggested in https://github.com/Pier-Two/Lantern.Discv5/pull/100#issuecomment-2184859927, i.e., we now have 3 separate packages.

To avoid confusion, the current `PierTwo.Lantern.Discv5` package must be unlisted from the NuGet feed.