### PR TITLE
Allow service overrides

### DIFF
--- a/src/Lantern.Discv5.WireProtocol/Discv5ProtocolBuilder.cs
+++ b/src/Lantern.Discv5.WireProtocol/Discv5ProtocolBuilder.cs
@@ -18,6 +18,7 @@ public class Discv5ProtocolBuilder(IServiceCollection services) : IDiscv5Protoco
     private IEnrEntryRegistry _entryRegistry = new EnrEntryRegistry();
     private ILoggerFactory _loggerFactory = LoggingOptions.Default;
     private ITalkReqAndRespHandler? _talkResponder;
+    private Action<IServiceCollection>? _servicesSetup;
     private IServiceProvider? _serviceProvider;
 
     public IDiscv5ProtocolBuilder WithConnectionOptions(ConnectionOptions connectionOptions)
@@ -98,6 +99,12 @@ public class Discv5ProtocolBuilder(IServiceCollection services) : IDiscv5Protoco
         return this;
     }
 
+    public IDiscv5ProtocolBuilder WithServices(Action<IServiceCollection> setup)
+    {
+        _servicesSetup = setup ?? throw new ArgumentNullException(nameof(setup));
+        return this;
+    }
+
     public IServiceProvider GetServiceProvider()
     {
         return _serviceProvider ?? throw new InvalidOperationException("Build() must be called before accessing the service provider.");
@@ -106,6 +113,7 @@ public class Discv5ProtocolBuilder(IServiceCollection services) : IDiscv5Protoco
     public IDiscv5Protocol Build()
     {
         services.AddDiscv5(_tableOptions, _connectionOptions, _sessionOptions, _entryRegistry, _enrBuilder.Build(), _loggerFactory, _talkResponder);
+        _servicesSetup?.Invoke(services);
         _serviceProvider = services.BuildServiceProvider();
         return _serviceProvider.GetRequiredService<IDiscv5Protocol>();
     }

--- a/src/Lantern.Discv5.WireProtocol/Discv5ProtocolServiceConfiguration.cs
+++ b/src/Lantern.Discv5.WireProtocol/Discv5ProtocolServiceConfiguration.cs
@@ -8,8 +8,8 @@ using Lantern.Discv5.WireProtocol.Session;
 using Lantern.Discv5.WireProtocol.Table;
 using Lantern.Discv5.WireProtocol.Utility;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Lantern.Discv5.WireProtocol;
 
@@ -64,61 +64,61 @@ public static class Discv5ProtocolServiceConfiguration
     private static void AddConnectionServices(IServiceCollection services, ConnectionOptions connectionOptions, SessionOptions sessionOptions, TableOptions tableOptions, ITalkReqAndRespHandler? talkResponder)
     {
         if (talkResponder != null)
-            services.TryAddSingleton(talkResponder);
+            services.AddSingleton(talkResponder);
 
         services.AddSingleton(connectionOptions);
         services.AddSingleton(sessionOptions);
         services.AddSingleton(tableOptions);
-        services.TryAddSingleton<IConnectionManager, ConnectionManager>();
-        services.TryAddSingleton<IUdpConnection, UdpConnection>();
+        services.AddSingleton<IConnectionManager, ConnectionManager>();
+        services.AddSingleton<IUdpConnection, UdpConnection>();
     }
 
     private static void AddIdentityServices(IServiceCollection services, IEnrEntryRegistry enrEntryRegistry, IEnr enr)
     {
         services.AddSingleton(enrEntryRegistry);
         services.AddSingleton(enr);
-        services.TryAddSingleton<IEnrFactory, EnrFactory>();
-        services.TryAddSingleton<IIdentityManager, IdentityManager>();
+        services.AddSingleton<IEnrFactory, EnrFactory>();
+        services.AddSingleton<IIdentityManager, IdentityManager>();
     }
 
     private static void AddTableServices(IServiceCollection services)
     {
-        services.TryAddSingleton<IRoutingTable, RoutingTable>();
-        services.TryAddSingleton<ITableManager, TableManager>();
-        services.TryAddSingleton<ILookupManager, LookupManager>();
+        services.AddSingleton<IRoutingTable, RoutingTable>();
+        services.AddSingleton<ITableManager, TableManager>();
+        services.AddSingleton<ILookupManager, LookupManager>();
     }
 
     private static void AddPacketServices(IServiceCollection services)
     {
-        services.TryAddSingleton<IPacketManager, PacketManager>();
-        services.TryAddSingleton<IPacketBuilder, PacketBuilder>();
-        services.TryAddSingleton<IPacketProcessor, PacketProcessor>();
-        services.TryAddSingleton<IPacketReceiver, PacketReceiver>();
-        services.TryAddSingleton<IPacketHandlerFactory, PacketHandlerFactory>();
-        services.TryAddTransient<OrdinaryPacketHandler>();
-        services.TryAddTransient<WhoAreYouPacketHandler>();
-        services.TryAddTransient<HandshakePacketHandler>();
+        services.AddSingleton<IPacketManager, PacketManager>();
+        services.AddSingleton<IPacketBuilder, PacketBuilder>();
+        services.AddSingleton<IPacketProcessor, PacketProcessor>();
+        services.AddSingleton<IPacketReceiver, PacketReceiver>();
+        services.AddSingleton<IPacketHandlerFactory, PacketHandlerFactory>();
+        services.AddTransient<OrdinaryPacketHandler>();
+        services.AddTransient<WhoAreYouPacketHandler>();
+        services.AddTransient<HandshakePacketHandler>();
     }
 
     private static void AddMessageServices(IServiceCollection services)
     {
-        services.TryAddSingleton<IMessageDecoder, MessageDecoder>();
-        services.TryAddSingleton<IMessageRequester, MessageRequester>();
-        services.TryAddSingleton<IMessageResponder, MessageResponder>();
-        services.TryAddSingleton<IRequestManager, RequestManager>();
+        services.AddSingleton<IMessageDecoder, MessageDecoder>();
+        services.AddSingleton<IMessageRequester, MessageRequester>();
+        services.AddSingleton<IMessageResponder, MessageResponder>();
+        services.AddSingleton<IRequestManager, RequestManager>();
     }
 
     private static void AddSessionServices(IServiceCollection services)
     {
-        services.TryAddSingleton<IAesCrypto, AesCrypto>();
-        services.TryAddSingleton<ISessionCrypto, SessionCrypto>();
-        services.TryAddSingleton<ISessionManager, SessionManager>();
+        services.AddSingleton<IAesCrypto, AesCrypto>();
+        services.AddSingleton<ISessionCrypto, SessionCrypto>();
+        services.AddSingleton<ISessionManager, SessionManager>();
     }
 
     private static void AddUtilityServices(IServiceCollection services)
     {
-        services.TryAddSingleton<IGracefulTaskRunner, GracefulTaskRunner>();
-        services.TryAddTransient<ICancellationTokenSourceWrapper, CancellationTokenSourceWrapper>();
-        services.TryAddSingleton<IRoutingTable, RoutingTable>();
+        services.AddSingleton<IGracefulTaskRunner, GracefulTaskRunner>();
+        services.AddTransient<ICancellationTokenSourceWrapper, CancellationTokenSourceWrapper>();
+        services.AddSingleton<IRoutingTable, RoutingTable>();
     }
 }

--- a/src/Lantern.Discv5.WireProtocol/Discv5ProtocolServiceConfiguration.cs
+++ b/src/Lantern.Discv5.WireProtocol/Discv5ProtocolServiceConfiguration.cs
@@ -8,8 +8,8 @@ using Lantern.Discv5.WireProtocol.Session;
 using Lantern.Discv5.WireProtocol.Table;
 using Lantern.Discv5.WireProtocol.Utility;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Lantern.Discv5.WireProtocol;
 
@@ -64,61 +64,61 @@ public static class Discv5ProtocolServiceConfiguration
     private static void AddConnectionServices(IServiceCollection services, ConnectionOptions connectionOptions, SessionOptions sessionOptions, TableOptions tableOptions, ITalkReqAndRespHandler? talkResponder)
     {
         if (talkResponder != null)
-            services.AddSingleton(talkResponder);
+            services.TryAddSingleton(talkResponder);
 
         services.AddSingleton(connectionOptions);
         services.AddSingleton(sessionOptions);
         services.AddSingleton(tableOptions);
-        services.AddSingleton<IConnectionManager, ConnectionManager>();
-        services.AddSingleton<IUdpConnection, UdpConnection>();
+        services.TryAddSingleton<IConnectionManager, ConnectionManager>();
+        services.TryAddSingleton<IUdpConnection, UdpConnection>();
     }
 
     private static void AddIdentityServices(IServiceCollection services, IEnrEntryRegistry enrEntryRegistry, IEnr enr)
     {
         services.AddSingleton(enrEntryRegistry);
         services.AddSingleton(enr);
-        services.AddSingleton<IEnrFactory, EnrFactory>();
-        services.AddSingleton<IIdentityManager, IdentityManager>();
+        services.TryAddSingleton<IEnrFactory, EnrFactory>();
+        services.TryAddSingleton<IIdentityManager, IdentityManager>();
     }
 
     private static void AddTableServices(IServiceCollection services)
     {
-        services.AddSingleton<IRoutingTable, RoutingTable>();
-        services.AddSingleton<ITableManager, TableManager>();
-        services.AddSingleton<ILookupManager, LookupManager>();
+        services.TryAddSingleton<IRoutingTable, RoutingTable>();
+        services.TryAddSingleton<ITableManager, TableManager>();
+        services.TryAddSingleton<ILookupManager, LookupManager>();
     }
 
     private static void AddPacketServices(IServiceCollection services)
     {
-        services.AddSingleton<IPacketManager, PacketManager>();
-        services.AddSingleton<IPacketBuilder, PacketBuilder>();
-        services.AddSingleton<IPacketProcessor, PacketProcessor>();
-        services.AddSingleton<IPacketReceiver, PacketReceiver>();
-        services.AddSingleton<IPacketHandlerFactory, PacketHandlerFactory>();
-        services.AddTransient<OrdinaryPacketHandler>();
-        services.AddTransient<WhoAreYouPacketHandler>();
-        services.AddTransient<HandshakePacketHandler>();
+        services.TryAddSingleton<IPacketManager, PacketManager>();
+        services.TryAddSingleton<IPacketBuilder, PacketBuilder>();
+        services.TryAddSingleton<IPacketProcessor, PacketProcessor>();
+        services.TryAddSingleton<IPacketReceiver, PacketReceiver>();
+        services.TryAddSingleton<IPacketHandlerFactory, PacketHandlerFactory>();
+        services.TryAddTransient<OrdinaryPacketHandler>();
+        services.TryAddTransient<WhoAreYouPacketHandler>();
+        services.TryAddTransient<HandshakePacketHandler>();
     }
 
     private static void AddMessageServices(IServiceCollection services)
     {
-        services.AddSingleton<IMessageDecoder, MessageDecoder>();
-        services.AddSingleton<IMessageRequester, MessageRequester>();
-        services.AddSingleton<IMessageResponder, MessageResponder>();
-        services.AddSingleton<IRequestManager, RequestManager>();
+        services.TryAddSingleton<IMessageDecoder, MessageDecoder>();
+        services.TryAddSingleton<IMessageRequester, MessageRequester>();
+        services.TryAddSingleton<IMessageResponder, MessageResponder>();
+        services.TryAddSingleton<IRequestManager, RequestManager>();
     }
 
     private static void AddSessionServices(IServiceCollection services)
     {
-        services.AddSingleton<IAesCrypto, AesCrypto>();
-        services.AddSingleton<ISessionCrypto, SessionCrypto>();
-        services.AddSingleton<ISessionManager, SessionManager>();
+        services.TryAddSingleton<IAesCrypto, AesCrypto>();
+        services.TryAddSingleton<ISessionCrypto, SessionCrypto>();
+        services.TryAddSingleton<ISessionManager, SessionManager>();
     }
 
     private static void AddUtilityServices(IServiceCollection services)
     {
-        services.AddSingleton<IGracefulTaskRunner, GracefulTaskRunner>();
-        services.AddTransient<ICancellationTokenSourceWrapper, CancellationTokenSourceWrapper>();
-        services.AddSingleton<IRoutingTable, RoutingTable>();
+        services.TryAddSingleton<IGracefulTaskRunner, GracefulTaskRunner>();
+        services.TryAddTransient<ICancellationTokenSourceWrapper, CancellationTokenSourceWrapper>();
+        services.TryAddSingleton<IRoutingTable, RoutingTable>();
     }
 }

--- a/src/Lantern.Discv5.WireProtocol/IDiscv5ProtocolBuilder.cs
+++ b/src/Lantern.Discv5.WireProtocol/IDiscv5ProtocolBuilder.cs
@@ -36,6 +36,8 @@ public interface IDiscv5ProtocolBuilder
 
     IDiscv5ProtocolBuilder WithTalkResponder(Action<ITalkReqAndRespHandler> configure);
 
+    IDiscv5ProtocolBuilder WithServices(Action<IServiceCollection> setup);
+
     IServiceProvider GetServiceProvider();
 
     IDiscv5Protocol Build();

--- a/tests/Lantern.Discv5.WireProtocol.Tests/Discv5ProtocolBuilderTests.cs
+++ b/tests/Lantern.Discv5.WireProtocol.Tests/Discv5ProtocolBuilderTests.cs
@@ -148,9 +148,9 @@ public class Discv5ProtocolBuilderTests
         var discv5Builder = new Discv5ProtocolBuilder(services);
 
         var serviceOverride = Mock.Of<IConnectionManager>();
-        services.AddSingleton(serviceOverride);
-
-        AddMandatoryConfigurations(discv5Builder, 30304).Build();
+        AddMandatoryConfigurations(discv5Builder, 30304)
+            .WithServices(s => s.AddSingleton(serviceOverride))
+            .Build();
 
         var serviceProvider = discv5Builder.GetServiceProvider();
         var serviceResolved = serviceProvider.GetRequiredService<IConnectionManager>();


### PR DESCRIPTION
This allows to override any of the default services:

```csharp
var discv5Builder = new Discv5ProtocolBuilder(services)
    .WithServices(s => s
        .AddSingleton<IConnectionManager, MyConnectionManager>()
        .AddSingleton<IUdpConnection, MyConnection>()
    )
    //...
```

My use case is to replace `IConnectionManager` and `IUdpConnection` to integrate with DotNetty.

In current version this is possible, but very cumbersome, since call to `AddDiscv5` replaces any of the user-registered variants.