### PR TITLE
Fix rlp collection length

### DIFF
--- a/src/Lantern.Discv5.Rlp/RlpEncoder.cs
+++ b/src/Lantern.Discv5.Rlp/RlpEncoder.cs
@@ -149,7 +149,7 @@ public static class RlpEncoder
             return array;
         }
 
-        return length < Constants.SizeThreshold
+        return length <= Constants.SizeThreshold
             ? ByteArrayUtils.JoinByteArrays(new[] { (byte)(shortOffset + length) }, array)
             : EncodeLargePrefix(array, largeOffset);
     }

--- a/tests/Lantern.Discv5.Rlp.Tests/RlpEncoderTests.cs
+++ b/tests/Lantern.Discv5.Rlp.Tests/RlpEncoderTests.cs
@@ -118,4 +118,22 @@ public class RlpEncoderTests
         };
         Assert.IsTrue(rlpEncoded.SequenceEqual(rlpExpected));
     }
+    
+    [Test]
+    public void Test_RlpEncoder_ShouldEncodeCollectionOfThresholdSize_Correctly()
+    {
+        var bytes = Enumerable.Range(0, 55).Select(_ => (byte)255).ToArray();
+        var rlpEncoded = RlpEncoder.EncodeCollectionOfBytes(bytes);
+        var rlpExpected = new byte[] { 192 + 55 }.Concat(bytes).ToArray();
+        Assert.IsTrue(rlpEncoded.SequenceEqual(rlpExpected));
+    }
+    
+    [Test]
+    public void Test_RlpEncoder_ShouldEncodeCollectionOfMoreThanThresholdSize_Correctly()
+    {
+        var bytes = Enumerable.Range(0, 56).Select(_ => (byte)255).ToArray();
+        var rlpEncoded = RlpEncoder.EncodeCollectionOfBytes(bytes);
+        var rlpExpected = new byte[] { 247 + 1, 56 }.Concat(bytes).ToArray();
+        Assert.IsTrue(rlpEncoded.SequenceEqual(rlpExpected));
+    }
 }


### PR DESCRIPTION
- Fix rlp collection of size 55 being encoded with length of size as if the size is more than 55.
- This cause deserialization error in shisui on pong message.