### PR TITLE
Two fixes for current discv5 hive tests

### DIFF
--- a/src/Lantern.Discv5.Enr/Enr.cs
+++ b/src/Lantern.Discv5.Enr/Enr.cs
@@ -1,4 +1,4 @@
-﻿using Lantern.Discv5.Enr.Entries;
+using Lantern.Discv5.Enr.Entries;
 using Lantern.Discv5.Enr.Identity;
 using Lantern.Discv5.Rlp;
 using Multiformats.Base;
@@ -140,6 +140,7 @@ public class Enr : IEnr, IEquatable<IEnr>
     private byte[] EncodeEnrContent()
     {
         return _entries
+            .OrderBy(r=>r.Key)
             .SelectMany(e => e.Value.EncodeEntry())
             .ToArray();
     }

--- a/src/Lantern.Discv5.WireProtocol/Packet/PacketConstants.cs
+++ b/src/Lantern.Discv5.WireProtocol/Packet/PacketConstants.cs
@@ -19,4 +19,5 @@ public static class PacketConstants
     public const int MaskingIvSize = 16;
     public const int NonceSize = 12;
     public const int RandomDataSize = 40;
+    internal const int MaxRequestIdSize = 8;
 }


### PR DESCRIPTION
Hive tests are available here:
https://github.com/ethereum/go-ethereum/blob/7e7925460507db9988088223ecd069af507815d6/cmd/devp2p/internal/v5test/discv5tests.go

Fixes:
PingLargeRequestID
FindnodeZeroDistance

